### PR TITLE
fix: Remove unused permission

### DIFF
--- a/swagger-viewer/app/manifest.json
+++ b/swagger-viewer/app/manifest.json
@@ -28,5 +28,5 @@
       "all_frames": false
     }
   ],
-  "permissions": ["tabs"]
+  "permissions": []
 }


### PR DESCRIPTION
## Why

This draft has been warned. Once your draft complies with Chrome Web Store policies, you must submit a new draft.

Version | 2.0.2
-- | --
Status | Warning
Violation date | Nov 2, 2021
  |  
Violation type | Use of Permissions
Details | Violation reference ID: Purple Potassium <br> Violation: The following permission(s) need not be requested for the methods/properties implemented by the item:tabs <br> How to rectify: Remove the above permission(s). The properties used by the items will continue to function even without requesting these permissions. <br> Relevant section of the program policy: Request access to the narrowest permissions necessary to implement your Product's features or services. Don't attempt to "future proof" your Product by requesting a permission that might benefit services or features that have not yet been implemented. (learn more)
Policy references | Developer Terms of Service <br> Program Policies <br> Branding Guidelines
